### PR TITLE
Incorporate Toaster Redux logic. Export Flow types and annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A library for Polymath's custom UI components.
 
 After cloning, run `yarn` to install all dependencies.
 
-Run `yarn dev` to automatically compile and lint JS and SCSS files as they're modified.
+Run `yarn dev` to automatically compile and lint JS and SCSS files as they're modified. You'll need to run a manual build to update the Flow types that the package exports: `yarn build:flow` or `yarn build`.

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,0 +1,98 @@
+// flow-typed signature: a2c406bd25fca4586c361574e555202d
+// flow-typed version: dcd1531faf/react-redux_v5.x.x/flow_>=v0.62.0
+
+import type { Dispatch, Store } from "redux";
+
+declare module "react-redux" {
+  import type { ComponentType, ElementConfig } from 'react';
+
+  declare export class Provider<S, A> extends React$Component<{
+    store: Store<S, A>,
+    children?: any
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string
+  ): Provider<*, *>;
+
+  /*
+
+  S = State
+  A = Action
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  MDP = Map dispatch to props object
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  Com = React Component
+  */
+
+  declare type MapStateToProps<SP: Object, RSP: Object> = (state: Object, props: SP) => RSP;
+
+  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+
+  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: MP
+  ) => RMP;
+
+  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
+    pure?: boolean,
+    withRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
+    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
+    storeKey?: string
+  |};
+
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
+
+  declare export function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
+    mapStateToProps: MapStateToProps<DP, RSP>,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<$Diff<OmitDispatch<ElementConfig<Com>>, RSP> & DP>;
+
+  declare export function connect<Com: ComponentType<*>>(
+    mapStateToProps?: null,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
+
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
+  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, RDP> & SP & DP>;
+
+  declare export function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
+    mapStateToProps?: null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
+  ): (Com) => ComponentType<$Diff<ElementConfig<Com>, DP> & OP>;
+
+  declare export function connect<Com: ComponentType<*>, MDP: Object>(
+    mapStateToProps?: null,
+    mapDispatchToProps: MDP
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
+
+  declare export function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToPRops: MDP
+  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, MDP> & SP>;
+
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+    mapStateToProps: ?MapStateToProps<SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
+    options: ConnectOptions<*, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+}

--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,0 +1,59 @@
+// flow-typed signature: cca4916b0213065533df8335c3285a4a
+// flow-typed version: cab04034e7/redux_v3.x.x/flow_>=v0.55.x
+
+declare module 'redux' {
+
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> =
+    (api: MiddlewareAPI<S, A, D>) =>
+      (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
+
+  declare export function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
+  declare export function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
+
+  declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/flow-typed/npm/reselect_v3.x.x.js
+++ b/flow-typed/npm/reselect_v3.x.x.js
@@ -1,0 +1,890 @@
+// flow-typed signature: 7242133add1d3bd16fc3e9d648152c63
+// flow-typed version: 00301f0d29/reselect_v3.x.x/flow_>=v0.47.x
+
+// flow-typed signature: 0199525b667f385f2e61dbeae3215f21
+// flow-typed version: b43dff3e0e/reselect_v3.x.x/flow_>=v0.28.x
+
+declare module "reselect" {
+  declare type Selector<-TState, TProps, TResult> =
+    (state: TState, props: TProps, ...rest: any[]) => TResult
+
+  declare type SelectorCreator = {
+    <TState, TProps, TResult, T1>(
+      selector1: Selector<TState, TProps, T1>,
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1>(
+      selectors: [Selector<TState, TProps, T1>],
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2>(
+      selectors: [Selector<TState, TProps, T1>, Selector<TState, TProps, T2>],
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      selector16: Selector<TState, TProps, T16>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>,
+        Selector<TState, TProps, T16>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>
+  };
+
+  declare type Reselect = {
+    createSelector: SelectorCreator,
+
+    defaultMemoize: <TFunc: Function>(
+      func: TFunc,
+      equalityCheck?: (a: any, b: any) => boolean
+    ) => TFunc,
+
+    createSelectorCreator: (
+      memoize: Function,
+      ...memoizeOptions: any[]
+    ) => SelectorCreator,
+
+    createStructuredSelector: <TState, TProps>(
+      inputSelectors: {
+        [k: string | number]: Selector<TState, TProps, any>
+      },
+      selectorCreator?: SelectorCreator
+    ) => Selector<TState, TProps, any>
+  };
+
+  declare module.exports: Reselect;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymath-ui",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "7.2.3",
@@ -34,7 +34,10 @@
     "carbon-icons": "^5.1.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-transition-group": "^2.2.1"
+    "react-redux": "^5.0.7",
+    "react-transition-group": "^2.2.1",
+    "redux": "^3.7.2",
+    "reselect": "^3.0.1"
   },
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "npm-run-all -p \"build:js --watch\" \"build:scss --watch\" \"lint -w\"",
+    "dev": "npm-run-all -p \"build:cjs --watch\" \"build:scss --watch\" \"lint -w\"",
     "lint": "esw --fix src",
     "typecheck": "flow",
     "precommit": "lint-staged && npm run typecheck",
-    "build": "npm-run-all -p 'build:*'",
-    "build:js": "babel src --out-dir dist",
+    "build": "npm run build:clean && npm run build:cjs && npm run build:scss && npm run build:flow",
+    "build:cjs": "babel src --out-dir dist",
     "build:scss": "node-sass-chokidar src/ -o dist/",
+    "build:flow": "for file in $(find ./src -name '*.js'); do cp \"$file\" `echo \"$file\" | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
+    "build:clean": "rm -rf ./dist && mkdir ./dist",
     "prepublish": "npm run build"
   },
   "license": "UNLICENSED",

--- a/src/components/toaster.js
+++ b/src/components/toaster.js
@@ -20,7 +20,7 @@ type Toast = {|
 
 export type ToastArgs = any
 
-export type ToasterProps = {|
+type Props = {|
   notify: ?Notify,
 |}
 
@@ -30,7 +30,7 @@ type State = {|
 
 const duration = 6000
 
-class ToasterUnwrapped extends Component<ToasterProps, State> {
+class ToasterUnwrapped extends Component<Props, State> {
   state = {
     toasts: []
   }
@@ -160,7 +160,7 @@ class ToasterUnwrapped extends Component<ToasterProps, State> {
   }
 }
 
-const connector = connect((state): ToasterProps => ({
+const connector = connect((state): Props => ({
   notify: getToasterState(state).notify,
 }))
 

--- a/src/components/toaster.js
+++ b/src/components/toaster.js
@@ -9,11 +9,13 @@ import { Transition } from 'react-transition-group'
 // $FlowFixMe
 import styles from '../style.css'
 
-export type Toast = {
+type Toast = {
   key: number,
   hiding: bool,
   data: Object,
 }
+
+export type ToastArgs = any
 
 type State = {
   toasts: Array<Toast>
@@ -24,7 +26,7 @@ export class Toaster extends Component<{}, State> {
     toasts: []
   }
 
-  show (toast: Toast, duration: number = 4000) {
+  show (toast: ToastArgs, duration: number = 4000) {
     this.setState((previousState) => {
       const toasts = previousState.toasts
       const newKey = toasts.reduce(

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,9 @@
 import 'carbon-components/css/carbon-components.min.css'
 
 export { TextInput } from './components/inputs'
-export { Toaster, ToasterContainer } from './components/toaster'
+export { Toaster } from './components/toaster'
 export type { ToastArgs } from './components/toaster'
+export type { Notify } from './redux/toaster/actions'
+export { notify } from './redux/toaster/actions'
+
+export { default as puiReducer } from './redux/reducer'

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@
 import 'carbon-components/css/carbon-components.min.css'
 
 export { TextInput } from './components/inputs'
-export { Toast, Toaster, ToasterContainer } from './components/toaster'
+export { Toaster, ToasterContainer } from './components/toaster'
+export type { ToastArgs } from './components/toaster'

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -1,0 +1,5 @@
+// @flow
+
+// eslint-disable-next-line no-unused-vars
+type _ExtractReturn<B, F: (...args: any[]) => B> = B;
+export type ExtractReturn<F> = _ExtractReturn<*, F>;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,0 +1,8 @@
+// @flow
+
+import { combineReducers } from 'redux'
+import toaster from './toaster/reducer'
+
+export default combineReducers({
+  toaster
+})

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -1,0 +1,1 @@
+export const getPUIState = (state) => state.pui

--- a/src/redux/toaster/actions.js
+++ b/src/redux/toaster/actions.js
@@ -1,0 +1,19 @@
+// @flow
+
+import type { Node } from 'react'
+
+import type { ExtractReturn } from '../helpers'
+
+export type Notify = {|
+  title: string,
+  isSuccess?: boolean,
+  subtitle?: ?string,
+  caption?: ?Node,
+  isPinned?: ?boolean,
+|}
+
+export const NOTIFY = 'polymath-ui/toaster/NOTIFY'
+export const notify = (notify: Notify) => ({ type: 'polymath-ui/toaster/NOTIFY', notify })
+
+export type ToasterAction =
+  | ExtractReturn<typeof notify>

--- a/src/redux/toaster/reducer.js
+++ b/src/redux/toaster/reducer.js
@@ -1,0 +1,24 @@
+// @flow
+
+import * as a from './actions'
+import type { Notify } from './actions'
+
+type ToasterState = {
+  notify: ?Notify
+}
+
+const defaultState = {
+  notify: null,
+}
+
+export default (state: ToasterState = defaultState, action: a.ToasterAction) => {
+  switch (action.type) {
+    case a.NOTIFY:
+      return {
+        ...state,
+        notify: action.notify,
+      }
+    default:
+      return state
+  }
+}

--- a/src/redux/toaster/selectors.js
+++ b/src/redux/toaster/selectors.js
@@ -1,0 +1,8 @@
+import { createSelector } from 'reselect'
+
+import { getPUIState } from '../selectors'
+
+export const getToasterState = createSelector(
+  getPUIState,
+  (puiState) => puiState.toaster
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-syntax-async-functions@^6.1.4, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,12 +437,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-external-helpers@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-syntax-async-functions@^6.1.4, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -2136,6 +2130,10 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2249,7 +2247,7 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.2.2, invariant@^2.2.3:
+invariant@^2.0.0, invariant@^2.2.2, invariant@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -2741,6 +2739,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.5, lodash-es@^4.2.1:
+  version "4.17.8"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.8.tgz#6fa8c8c5d337481df0bdf1c0d899d42473121e45"
+
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
@@ -2781,7 +2783,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -3685,6 +3687,17 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-redux@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.0.0"
+    lodash "^4.17.5"
+    lodash-es "^4.17.5"
+    loose-envify "^1.1.0"
+    prop-types "^15.6.0"
+
 react-transition-group@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
@@ -3769,6 +3782,15 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -3937,6 +3959,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -4333,6 +4359,10 @@ symbol-observable@1.0.1:
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
+
+symbol-observable@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
This brings the action creator and reducer for toaster notifications into polymath-ui in a style similar to how redux-form works. The polymath-ui reducer should be at the `pui` key on the root state.

The method for creating the toaster is different from polymath-app. Instead of creating it in componentDidMount and letting it place itself in the DOM, we place it in our component tree because otherwise it won't receive the Redux state from the app's Redux Provider. Maybe we could pass the store to the toaster and have it create a separate Provider? There's not much benefit though.

Another problem this PR fixes is that what we were exporting from our packages didn't contain any of the Flow types or function type annotations. After struggling with Rollup I found a simple way to export those types, using the [graphql](https://github.com/graphql/graphql-js) library as an example. Now for the most part Nuclide seems to be picking up the types and using them in its autocomplete. We'll want to do something similar with polymath.js_v2 and any other dependencies we create that use Flow.

Finally, the toast duration is fixed at 6 seconds but toasts can be pinned with the isPinned property.

Package version is updated to 0.1.10.