### PR TITLE
Add support for "-" and "." in ticker symbol

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -28,7 +28,10 @@ export const gt = (x: number) => (value: ?number) =>
   value && value <= x ? `Must be greater than ${x}.` : null
 
 export const alphanumeric = (value: ?string) =>
-  value && !/^[a-z0-9./-]+$/i.test(value) ? 'Invalid characters.' : null
+  value && !/^[a-z0-9]+$/i.test(value) ? 'Invalid characters.' : null
+
+export const regex = (expr: any, value: ?string) =>
+  value && !expr.test(value) ? 'Only alphanumeric characters, hyphens and fullstops are allowed' : null
 
 export const email = (value: ?string) =>
   value && !/^[A-Z0-9._%+-]+@([A-Z0-9-]+\.)+[A-Z0-9-]+$/i.test(value)

--- a/src/validate.js
+++ b/src/validate.js
@@ -30,8 +30,8 @@ export const gt = (x: number) => (value: ?number) =>
 export const alphanumeric = (value: ?string) =>
   value && !/^[a-z0-9]+$/i.test(value) ? 'Invalid characters.' : null
 
-export const regex = (expr: any, value: ?string) =>
-  value && !expr.test(value) ? 'Only alphanumeric characters, hyphens and periods are allowed' : null
+export const regex = (expr: any, value: ?string, error_msg: string) =>
+  value && !expr.test(value) ? error_msg : null
 
 export const email = (value: ?string) =>
   value && !/^[A-Z0-9._%+-]+@([A-Z0-9-]+\.)+[A-Z0-9-]+$/i.test(value)

--- a/src/validate.js
+++ b/src/validate.js
@@ -28,7 +28,7 @@ export const gt = (x: number) => (value: ?number) =>
   value && value <= x ? `Must be greater than ${x}.` : null
 
 export const alphanumeric = (value: ?string) =>
-  value && !/^[a-z0-9]+$/i.test(value) ? 'Invalid characters.' : null
+  value && !/^[a-z0-9./-]+$/i.test(value) ? 'Invalid characters.' : null
 
 export const email = (value: ?string) =>
   value && !/^[A-Z0-9._%+-]+@([A-Z0-9-]+\.)+[A-Z0-9-]+$/i.test(value)

--- a/src/validate.js
+++ b/src/validate.js
@@ -31,7 +31,7 @@ export const alphanumeric = (value: ?string) =>
   value && !/^[a-z0-9]+$/i.test(value) ? 'Invalid characters.' : null
 
 export const regex = (expr: any, value: ?string) =>
-  value && !expr.test(value) ? 'Only alphanumeric characters, hyphens and fullstops are allowed' : null
+  value && !expr.test(value) ? 'Only alphanumeric characters, hyphens and periods are allowed' : null
 
 export const email = (value: ?string) =>
   value && !/^[A-Z0-9._%+-]+@([A-Z0-9-]+\.)+[A-Z0-9-]+$/i.test(value)

--- a/src/validate.js
+++ b/src/validate.js
@@ -30,8 +30,8 @@ export const gt = (x: number) => (value: ?number) =>
 export const alphanumeric = (value: ?string) =>
   value && !/^[a-z0-9]+$/i.test(value) ? 'Invalid characters.' : null
 
-export const regex = (expr: any, value: ?string, error_msg: string) =>
-  value && !expr.test(value) ? error_msg : null
+export const regex = (expr: any, value: ?string, errorMessage: string) =>
+  value && !expr.test(value) ? errorMessage : null
 
 export const email = (value: ?string) =>
   value && !/^[A-Z0-9._%+-]+@([A-Z0-9-]+\.)+[A-Z0-9-]+$/i.test(value)


### PR DESCRIPTION
Fix UI: Add support for "-" and "." in addition to letters and numbes in the Token Symbol