### PR TITLE
bugfix: cursor changes when email field is trimmed via normalize

### DIFF
--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -10,6 +10,7 @@ type Props = {
     onChange: (any) => void,
   },
   label: Node,
+  type: string,
   meta: {
     touched: boolean,
     error: string
@@ -21,6 +22,7 @@ type Props = {
 export default ({
   input,
   label,
+  type,
   meta: { touched, error },
   className,
   onChangeCode,
@@ -39,7 +41,10 @@ export default ({
       if (onChangeCode) { // $FlowFixMe
         onChangeCode(value)
       }
-      return input.onChange(value || '')
+      if(type === 'email')
+      {return input.onChange(value.trim() || '')}
+      else
+      {return input.onChange(value || '')}
     }}
     {...rest}
   />)

--- a/src/modules/account/SignUpForm.js
+++ b/src/modules/account/SignUpForm.js
@@ -34,6 +34,7 @@ class SignUpForm extends Component<Props> {
         />
         <Field
           name='email'
+          type='email'
           component={TextInput}
           label='Email'
           placeholder='Enter your email address'


### PR DESCRIPTION
To avoid the previous issue with the cursor change (due to a redux form bug), I opted to modify the TextInput component so that when it has a type of 'email' that the input is trimmed